### PR TITLE
[Master] Add watcher concept

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "use-inputs-example",
   "homepage": "https://@bellawatt.github.io/use-inputs",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "license": "MIT",
   "private": true,
   "dependencies": {

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -9,8 +9,18 @@ export default () => {
     animal: 'platypus',
   }
 
+  const watchers = {
+    name: ({name}) => {
+      if (name.length % 2 === 0) {
+        return {animal: 'playtpus'};
+      }
+
+      return {animal: 'manatee'};
+    }
+  }
+
   return (
-    <Inputs defaults={defaults}>
+    <Inputs defaults={defaults} watch={watchers}>
       <Textbox />
       <Report />
     </Inputs>

--- a/src/Inputs.js
+++ b/src/Inputs.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { useQueryString, useLocalStorage, useDebounceEffect } from '@bellawatt/react-hooks'
 import InputContext from './context'
 
-const Inputs = ({defaults, children, options}) => {
+const Inputs = ({defaults, children, options, watch = {}}) => {
   const { debounceDelay = 500, localStorageName = 'inputs' } = options || {}
 
   const [urlInputs, updateQueryString] = useQueryString()
@@ -15,7 +15,15 @@ const Inputs = ({defaults, children, options}) => {
     ...(hasUrlInputs ? urlInputs : localInputs),
   })
 
-  const setInput = obj => setInputs(current => ({...current, ...obj}))
+  const setInput = obj => {
+    const watcherChanges = Object.keys(obj).reduce((changes, key) => {
+      if (! watch[key]) return changes;
+
+      return {...changes, ...(watch[key]({...inputs, ...obj, ...changes}))}
+    }, {});
+    
+    setInputs(current => ({...current, ...obj, ...watcherChanges}))
+  }
 
   useDebounceEffect(
     () => {


### PR DESCRIPTION
### What

The PR is to create a concept called "watchers" within this package that allows you to set an object of watchers and corresponding function calls from the top level of context.

### What

I started thinking about this in order to solve two problems we were having with `useEffect` in a project:

- Every usage was to change the value of one param in response to a change in another. With useEffect, this resulted in double renders each time and some occasional race conditions.
- The useEffect calls were spread across multiple components, making it difficult to remember and track what reactions were watching which actions. This type of spread would encourage more race conditions, infinite loops, and general spaghetti code.

### How

The watchers concept works as follows:

In one place (wherever you initially define your context defaults at the top of the app) you can declare an object of watchers. This object has keys that represent the value you want to watch and a function that is called whenever that value is changed* which is passed all data currently held in context. The function should return an object of key: values that represents any values you want to set in reaction to the change.

The example in the changes is the best way to see the code. That function will be called every time the value of name changes. It's passed all data in context `{name, animal}`, and based on the name it changes the value of animal.

### FAQ

**Does this replace useEffect?**
Not in every case, no. This allows `useEffect` to only be used only for pure side effects and not for situations where we want to change other data held in context.

**Does it really watch for changes? Why the * above?**
No, it actually doesn't. The watcher will fire anytime the`setInput` function is called with a watched key. In practice, if you called `setInput({name: 'Brandon'})` 10 times, the watcher would also fire a corresponding 10 times.

**Why would I want to move all of these watchers to the top level instead of defining them where relevant?**
Where's more relevant than the source of the data? In theory, defining them in individual components where they're most relevant seems better, but in practice it can quickly lead to a mess. Having them together forces us to think about how they interact and what we're asking the app to do on each change. I would imagine they all live in the same file which is imported at the root level.

**Does this eliminate race conditions?**
For individual data held in context, yes it does. The watchers run BEFORE any data has actually been changed in state, so there's no chance of a race condition given that both the inputs and the results of the watchers are changed at the exact same time.

**What's the order of precedence?**
Result of watchers > setInput > existing data. The order that the individual watchers are run should not be assumed. 

**Could this trigger an infinite loop?**
It shouldn't. The results of a watchers WILL NOT trigger the watchers themselves. If we added a watcher for `animal` in the below example, it would not be triggered by the change in `animal` value after the `name` watcher has run.
