### PR TITLE
Add computed values

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -19,8 +19,12 @@ export default () => {
     }
   }
 
+  const computed = {
+    animals: ({animal}) => ['stringray', animal],
+  };
+
   return (
-    <Inputs defaults={defaults} watch={watchers}>
+    <Inputs defaults={defaults} watch={watchers} computed={computed}>
       <Textbox />
       <Report />
     </Inputs>

--- a/example/src/Report.js
+++ b/example/src/Report.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { useInputs } from '@bellawatt/use-inputs'
 
 const Report = () => {
-  const { name, animal } = useInputs()
+  const { name, animal, animals } = useInputs()
 
   return (
     <div>
@@ -11,6 +11,12 @@ const Report = () => {
         name: {name} <br />
         animal: {animal}
       </pre>
+      <h3>Cool Animals</h3>
+      <ol>
+        {animals.map(coolAnimal => (
+          <li key={coolAnimal}>{coolAnimal}</li>
+        ))}
+      </ol>
     </div>
   )
 }

--- a/src/Inputs.js
+++ b/src/Inputs.js
@@ -2,17 +2,24 @@ import React, {useState} from 'react'
 import PropTypes from 'prop-types'
 import { useQueryString, useLocalStorage, useDebounceEffect } from '@bellawatt/react-hooks'
 import InputContext from './context'
+import { omit } from './helpers';
 
-const Inputs = ({defaults, children, options, watch = {}}) => {
+const Inputs = ({defaults, children, options, watch = {}, computed = {}}) => {
   const { debounceDelay = 500, localStorageName = 'inputs' } = options || {}
 
   const [urlInputs, updateQueryString] = useQueryString()
   const [localInputs, setLocalInputs] = useLocalStorage(localStorageName)
   const hasUrlInputs = Object.keys(urlInputs).length > 0
+  const computedParams = Object.keys(computed);
+
+  const getComputedValues = (originalObj) => computedParams.reduce((fields, key) => {
+    return {...fields, [key]: computed[key]({...originalObj})};
+  }, {});
 
   const [inputs, setInputs] = useState({
     ...defaults,
     ...(hasUrlInputs ? urlInputs : localInputs),
+    ...getComputedValues({...defaults, ...(hasUrlInputs ? urlInputs : localInputs)}),
   })
 
   const setInput = obj => {
@@ -21,14 +28,18 @@ const Inputs = ({defaults, children, options, watch = {}}) => {
 
       return {...changes, ...(watch[key]({...inputs, ...obj, ...changes}))}
     }, {});
-    
-    setInputs(current => ({...current, ...obj, ...watcherChanges}))
+
+    const objWithWatcher = {...obj, ...watcherChanges};
+
+    const computedValues = getComputedValues(objWithWatcher);
+
+    setInputs(current => ({...current, ...objWithWatcher, ...computedValues}))
   }
 
   useDebounceEffect(
     () => {
-      updateQueryString(inputs)
-      setLocalInputs(inputs)
+      updateQueryString(omit(computedParams, inputs))
+      setLocalInputs(omit(computedParams, inputs))
     },
     debounceDelay,
     [inputs]

--- a/src/Inputs.js
+++ b/src/Inputs.js
@@ -16,11 +16,11 @@ const Inputs = ({defaults, children, options, watch = {}, computed = {}}) => {
     return {...fields, [key]: computed[key]({...originalObj})};
   }, {});
 
-  const [inputs, setInputs] = useState({
-    ...defaults,
-    ...(hasUrlInputs ? urlInputs : localInputs),
-    ...getComputedValues({...defaults, ...(hasUrlInputs ? urlInputs : localInputs)}),
-  })
+  const [inputs, setInputs] = useState(() => {
+    const originalValues = {...defaults, ...(hasUrlInputs ? urlInputs : localInputs)};
+
+    return {...originalValues, ...getComputedValues(originalValues)};
+  });
 
   const setInput = obj => {
     const watcherChanges = Object.keys(obj).reduce((changes, key) => {
@@ -31,9 +31,7 @@ const Inputs = ({defaults, children, options, watch = {}, computed = {}}) => {
 
     const objWithWatcher = {...obj, ...watcherChanges};
 
-    const computedValues = getComputedValues(objWithWatcher);
-
-    setInputs(current => ({...current, ...objWithWatcher, ...computedValues}))
+    setInputs(current => ({...current, ...objWithWatcher, ...getComputedValues(objWithWatcher)}))
   }
 
   useDebounceEffect(
@@ -58,6 +56,8 @@ Inputs.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
   ]).isRequired,
   defaults: PropTypes.object,
+  watch: PropTypes.object,
+  computed: PropTypes.object,
   options: PropTypes.shape({
     debounceDelay: PropTypes.number,
     localStorageName: PropTypes.string,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,5 @@
+export const omit = (keysToOmit, obj) => 
+  Object.fromEntries(
+    Object.entries(obj)
+      .filter(([key]) => !keysToOmit.includes(key))
+  );


### PR DESCRIPTION
This PR adds the concept of `computed values`.

Computed values are derived from an object of functions the same way watchers are, but have two key differences:

`computed values` are not persisted in state or local storage
`computed values` do not affect any other value (but could overwrite them).

Computed values currently execute after watches, but the order should not be relied on at this point.